### PR TITLE
Rework ticket permission overwrites and reapply on move

### DIFF
--- a/commands/slashcommands/move.js
+++ b/commands/slashcommands/move.js
@@ -74,7 +74,7 @@ module.exports = {
                 client,
                 guild: channel.guild,
                 ticketType,
-                category
+                userId: channel.topic,
             });
             if (Array.isArray(overwrites) && overwrites.length > 0) {
                 await channel.permissionOverwrites.set(overwrites);

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -921,7 +921,7 @@ module.exports = async function (client, interaction) {
                             client,
                             guild: interaction.guild,
                             ticketType: displayType,
-                            category
+                            userId: interaction.channel.topic,
                         });
                         if (Array.isArray(overwrites) && overwrites.length > 0) await interaction.channel.permissionOverwrites.set(overwrites).catch(()=>{});
                     } catch (error) {
@@ -1423,11 +1423,20 @@ module.exports = async function (client, interaction) {
                     `Could not find a pinned ticket metadata embed to update after modal move for channel ${channel.name}(${channel.id}).`
                 );
             }
-            // Move and rename
+            // Move, rename, and reapply permissions for target ticket type
             let renameSucceeded = true;
             try {
-                await channel.setParent(ctx.categoryId);
+                await channel.setParent(ctx.categoryId, { lockPermissions: true });
                 await channel.setName(ctx.newName);
+                const overwrites = perms.buildPermissionOverwritesForTicketType({
+                    client,
+                    guild: channel.guild,
+                    ticketType: ctx.ticketType,
+                    userId: channel.topic,
+                });
+                if (Array.isArray(overwrites) && overwrites.length > 0) {
+                    await channel.permissionOverwrites.set(overwrites);
+                }
             } catch (error) {
                 renameSucceeded = false;
                 func.handle_errors(error, client, 'move.js', null);

--- a/utils/permissions.js
+++ b/utils/permissions.js
@@ -46,53 +46,48 @@ function userHasAccessToTicketType({ userRoleIds, ticketType, config, adminRoleI
 	return false;
 }
 
-function buildPermissionOverwritesForTicketType({ client, guild, ticketType, category = null }) {
+/**
+ * Channel overwrites for a ticket — matches openTicket in functions.js (config roles only,
+ * not category inheritance). Replaces all overwrites on move so old type roles lose access.
+ */
+function buildPermissionOverwritesForTicketType({ client, guild, ticketType, userId = null }) {
 	const config = client?.config || {};
 	const staffGuild = guild || (client && client.guilds && client.guilds.cache.get(config.channel_ids?.staff_guild_id));
-	if (!staffGuild) return [];
-	const everyoneId = staffGuild.id;
-	const botId = client.user.id;
-	const accessRoles = getAccessRolesForTicketType(ticketType, config);
-	const merged = new Map();
-	const upsert = (id, allow = [], deny = []) => {
-		if (!id) return;
-		const existing = merged.get(String(id)) || { id: String(id), allow: new Set(), deny: new Set() };
-		for (const perm of allow) {
-			existing.allow.add(perm);
-			existing.deny.delete(perm);
-		}
-		for (const perm of deny) {
-			existing.deny.add(perm);
-			existing.allow.delete(perm);
-		}
-		merged.set(String(id), existing);
-	};
+	if (!staffGuild || !client?.user?.id) return [];
 
-	// Start from the target category's overwrites so inherited access remains valid after move.
-	if (category && category.permissionOverwrites && category.permissionOverwrites.cache) {
-		for (const overwrite of category.permissionOverwrites.cache.values()) {
-			upsert(
-				overwrite.id,
-				overwrite.allow?.toArray?.() || [],
-				overwrite.deny?.toArray?.() || []
-			);
-		}
+	const qf = getQuestionFileForType(ticketType);
+	const accessRoleIDs = Array.isArray(qf?.['access-role-id']) ? qf['access-role-id'].filter(Boolean) : [];
+
+	const overwrites = [
+		{ id: staffGuild.id, deny: ['ViewChannel', 'AddReactions'] },
+		{
+			id: client.user.id,
+			allow: ['ViewChannel', 'SendMessages', 'AddReactions', 'ManageThreads'],
+		},
+	];
+
+	if (config?.role_ids?.default_admin_role_id) {
+		overwrites.push({
+			id: config.role_ids.default_admin_role_id,
+			allow: ['ViewChannel', 'SendMessages'],
+		});
 	}
 
-	// Enforce ticket privacy and required bot access.
-	upsert(everyoneId, [], ['ViewChannel', 'AddReactions']);
-	upsert(botId, ['ViewChannel', 'SendMessages', 'AddReactions', 'ManageThreads'], []);
-
-	// Ensure ticket access roles can view and respond.
-	for (const roleId of accessRoles) {
-		upsert(roleId, ['ViewChannel', 'SendMessages'], []);
+	const seen = new Set(overwrites.map((o) => String(o.id)));
+	for (const roleId of accessRoleIDs) {
+		if (!roleId || seen.has(String(roleId))) continue;
+		seen.add(String(roleId));
+		overwrites.push({ id: roleId, allow: ['ViewChannel', 'SendMessages'] });
 	}
 
-	return Array.from(merged.values()).map(x => ({
-		id: x.id,
-		allow: Array.from(x.allow),
-		deny: Array.from(x.deny)
-	}));
+	if (qf?.internal && userId && /^\d{17,19}$/.test(String(userId)) && !seen.has(String(userId))) {
+		overwrites.push({
+			id: String(userId),
+			allow: ['ViewChannel', 'SendMessages', 'ReadMessageHistory'],
+		});
+	}
+
+	return overwrites;
 }
 
 module.exports = {


### PR DESCRIPTION
Use the channel.topic (userId) when building permission overwrites and reapply permissions after moving/renaming tickets. Updated move.js and interactionCreate.js to pass userId: channel.topic and to setParent with lockPermissions, then rebuild and set permission overwrites. Refactored utils/permissions.js: buildPermissionOverwritesForTicketType now accepts userId, removes category-inheritance/merge logic, and constructs a deterministic list of overwrites from the staff guild, bot, admin role, question-file access roles, and the ticket owner for internal types. Added guards for missing guild or bot user and kept behavior focused on explicit config roles so old type roles lose access after a move.